### PR TITLE
Use caching for building rust

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-**/target/
 cli/signal/grafana
 cli/signal/target
-target/
-node_modules/
+**/node_modules/

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,36 +5,73 @@ on:
     - main
 
 jobs:
-  docker:
+  build:
     runs-on: ubuntu-latest
     steps:
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_NAME }}
-        password: ${{ secrets.DOCKERHUB }}
+    - uses: actions/checkout@v2
 
-    - name: Build flnode
-      uses: docker/build-push-action@v2
+    - uses: actions/cache@v2
       with:
-        tags: fledgre/flnode:latest
-        file: Dockerfile.flnode
-        push: true
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
 
-    - name: Build Signalling server
-      uses: docker/build-push-action@v2
+    - uses: jetli/wasm-pack-action@v0.3.0
       with:
-        tags: fledgre/signal:latest
-        file: Dockerfile.signal
-        push: true
+        version: 'latest'
+
+    - name: Build signal server
+      run: |
+        cargo build --release -p signal
+
+    - name: Build flnode for docker server
+      run: |
+        cd cli/flnode; make build
+        head static/wasm.js
+        ls
+        ls ../../target/*
+        pwd
 
     - name: Build web server
-      uses: docker/build-push-action@v2
-      with:
-        tags: fledgre/web:latest
-        file: Dockerfile.web
-        push: true
+      run: |
+        cd wasm/web; make build
 
+    - uses: mr-smithers-excellent/docker-build-push@v5
+      with:
+        image: fledgre/signal
+        registry: docker.io
+        dockerfile: Dockerfile.signal
+        username: ${{ secrets.DOCKERHUB_NAME }}
+        password: ${{ secrets.DOCKERHUB }}
+        tags: latest
+
+    - uses: mr-smithers-excellent/docker-build-push@v5
+      with:
+        image: fledgre/flnode
+        registry: docker.io
+        dockerfile: Dockerfile.flnode
+        username: ${{ secrets.DOCKERHUB_NAME }}
+        password: ${{ secrets.DOCKERHUB }}
+        tags: latest
+
+    - uses: mr-smithers-excellent/docker-build-push@v5
+      with:
+        image: fledgre/web
+        registry: docker.io
+        dockerfile: Dockerfile.web
+        username: ${{ secrets.DOCKERHUB_NAME }}
+        password: ${{ secrets.DOCKERHUB }}
+        tags: latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: 
+      - build
+
+    steps:
     - name: Update signal.fledg.re
       uses: appleboy/ssh-action@master
       with:

--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -3,9 +3,13 @@ on:
   pull_request:
     branches:
     - main
+  # This is needed for actions/cache to copy the cache over to the default branch
+  push:
+    branches:
+    - main
 
 jobs:
-  docker:
+  wasm-test:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch
@@ -13,8 +17,20 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
+    - uses: jetli/wasm-pack-action@v0.3.0
+      with:
+        version: 'latest'
+
     - name: Run wasm-test
       run: |
-        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         cd wasm/lib/src
         wasm-pack test --chrome --headless

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+
+members = [
+    "cli/signal",
+    "cli/flnode",
+    "wasm/web",
+    "wasm/lib",
+    "common",
+    "vendor/names"
+]

--- a/Dockerfile.flnode
+++ b/Dockerfile.flnode
@@ -1,14 +1,6 @@
-FROM rust:latest as builder
-RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-WORKDIR /usr/src/flnode
-COPY . .
-RUN make -C cli/flnode build
-
 FROM node:latest
-COPY --from=builder /usr/src/flnode/cli/flnode/run /fledger-src/run
-COPY --from=builder /usr/src/flnode/cli/flnode/static /fledger-src/static
-#COPY run /fledger-src/run
-#COPY static /fledger-src/static
 WORKDIR /fledger
-RUN cd /fledger-src/run; npm i -g node-pre-gyp; npm ci
-CMD ["node", "/fledger-src/run/main.js"]
+COPY cli/flnode/run /fledger-bin/run
+COPY cli/flnode/static /fledger-bin/static
+RUN cd /fledger-bin/run; npm i -g node-pre-gyp; npm ci
+ENTRYPOINT ["node", "/fledger-bin/run/main.js"]

--- a/Dockerfile.signal
+++ b/Dockerfile.signal
@@ -1,9 +1,4 @@
-FROM rust:latest as builder
-WORKDIR /usr/src/signal
-COPY . .
-RUN cargo install --path cli/signal
-
-FROM debian:buster-slim
-COPY --from=builder /usr/local/cargo/bin/signal /usr/local/bin/signal
-RUN apt-get update && apt-get install -y libssl1.1 && rm -rf /var/lib/apt/lists/*
-CMD ["signal"]
+FROM rust
+WORKDIR /fledger
+COPY ./target/release/signal signal
+ENTRYPOINT ["/fledger/signal"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,11 +1,4 @@
-FROM rust:latest as builder
-WORKDIR /usr/src/fledger
-COPY . .
-RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-RUN cp -a wasm/web/static .
-RUN make -C wasm/web build
-
 FROM joseluisq/static-web-server
-COPY --from=builder /usr/src/fledger/wasm/web/static/ /var/www
+COPY wasm/web/static/ /var/www/
 ENV SERVER_NAME=fledger-web
 ENV SERVER_ROOT=/var/www

--- a/cli/flnode/Cargo.toml
+++ b/cli/flnode/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm"
+name = "flnode"
 version = "0.1.0"
 authors = ["Linus Gasser <linus@gasser.blue>"]
 edition = "2018"

--- a/cli/flnode/Makefile
+++ b/cli/flnode/Makefile
@@ -1,6 +1,7 @@
 src := $(shell find src ../../common ../../wasm/lib ../../vendor -name "*.rs")
 wasm := static/wasm_bg.wasm
-build = wasm-pack build --debug --target nodejs --out-name wasm \
+TARGET := --release
+build = wasm-pack build ${TARGET} --target nodejs --out-name wasm \
 	--out-dir ./static -- $(FEATURES)
 
 clean:
@@ -26,4 +27,5 @@ ${wasm}: ${src}
 	${build}
 
 build_local: FEATURES=--features local
+build_local: TARGET=--debug
 build_local: build

--- a/cli/flnode/src/lib.rs
+++ b/cli/flnode/src/lib.rs
@@ -1,7 +1,4 @@
-use common::node::{
-    ext_interface::{DataStorage, Logger},
-    logic::Stat,
-};
+use common::node::{config::NODE_VERSION, ext_interface::{DataStorage, Logger}, logic::Stat};
 
 use common::node::Node;
 
@@ -89,7 +86,7 @@ pub async fn run_app() {
     console_error_panic_hook::set_once();
 
     let logger = Box::new(ConsoleLogger {});
-    logger.info("starting app for now!");
+    logger.info(&format!("Starting app with version {}", NODE_VERSION));
 
     let mut node = match start(logger.clone(), URL).await {
         Ok(node) => node,

--- a/cli/signal/src/main.rs
+++ b/cli/signal/src/main.rs
@@ -1,12 +1,12 @@
+mod config;
 /// Very simple rendez-vous server that allows new nodes to send their node_info.
 /// It also allows the nodes to fetch all existing node_infos of all the other nodes.
 mod state;
-mod config;
 
-use structopt::StructOpt;
-use log::{warn, info, error};
-use flexi_logger::Logger;
 use async_trait::async_trait;
+use flexi_logger::Logger;
+use log::{error, info, warn};
+use structopt::StructOpt;
 
 use std::{
     net::{TcpListener, TcpStream},
@@ -15,11 +15,8 @@ use std::{
 };
 use tungstenite::{accept, protocol::Role, Message, WebSocket};
 
-use common::{
-    signal::websocket::{
-        MessageCallbackSend, NewConnectionCallback, WSMessage, WebSocketConnectionSend,
-        WebSocketServer,
-    },
+use common::signal::websocket::{
+    MessageCallbackSend, NewConnectionCallback, WSMessage, WebSocketConnectionSend, WebSocketServer,
 };
 use config::Config;
 
@@ -47,7 +44,7 @@ impl UnixWebSocket {
             for stream in server.incoming() {
                 let mut cb_mutex = uws_cl.lock().unwrap();
                 if let Some(cb) = cb_mutex.as_mut() {
-                    match UnixWSConnection::new(stream.unwrap()){
+                    match UnixWSConnection::new(stream.unwrap()) {
                         Ok(conn) => cb(conn),
                         Err(e) => println!("Error while getting connection: {:?}", e),
                     }
@@ -106,21 +103,26 @@ impl WebSocketConnectionSend for UnixWSConnection {
     }
 
     async fn send(&mut self, msg: String) -> Result<(), String> {
-        self.websocket.write_message(Message::Text(msg)).map_err(|e| e.to_string())?;
+        self.websocket
+            .write_message(Message::Text(msg))
+            .map_err(|e| e.to_string())?;
         Ok(())
     }
 }
 
 fn main() {
     let cfg = Config::from_args();
-    Logger::with_str("error, signal=".to_string() + cfg.logger_str()).start().unwrap();
+    Logger::with_str("error, signal=".to_string() + cfg.logger_str())
+        .start()
+        .unwrap();
     let ws = Box::new(UnixWebSocket::new());
     let port = cfg.port;
-    match ServerState::new(cfg, ws){
+    match ServerState::new(cfg, ws) {
         Ok(state) => {
-    info!("Server started and listening on port {}", port);
-    state.wait_done();
-        },
+            info!("Something something 123456789abc");
+            info!("Server started and listening on port {}", port);
+            state.wait_done();
+        }
         Err(e) => error!("Couldn't start server: {}", e),
     }
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,6 +14,8 @@ toml = "0.5"
 rand = "0.8.0"
 async-trait = "0.1.42"
 
+# The "js" is to make sure it also works for the flnode and wasm/web
+getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = { version = "0.2.69", features = ["serde-serialize"]  }
 js-sys = "0.3.46"
 wasm-bindgen-futures = "0.4.19"

--- a/common/src/node/config.rs
+++ b/common/src/node/config.rs
@@ -1,7 +1,7 @@
 use super::types::U256;
 use serde_derive::{Deserialize, Serialize};
 
-pub const NODE_VERSION: u64 = 0x2021032620;
+pub const NODE_VERSION: u64 = 0x202104041345;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct NodeInfo {

--- a/wasm/web/Cargo.toml
+++ b/wasm/web/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm"
+name = "wasm-web"
 version = "0.1.0"
 authors = ["Linus Gasser <linus@gasser.blue>"]
 edition = "2018"

--- a/wasm/web/Makefile
+++ b/wasm/web/Makefile
@@ -1,22 +1,25 @@
 miniserve := $(shell echo $$HOME )/.cargo/bin/miniserve
+wasm := static/wasm_bg.wasm
 src := $(shell find src -name "*.rs")
-build = wasm-pack build --debug --target web --out-name wasm \
+TARGET := --release
+build = wasm-pack build ${TARGET} --target web --out-name wasm \
 	--out-dir ./static -- $(FEATURES)
 
-serve: static/wasm_bg.wasm ${miniserve}
+serve: ${wasm} ${miniserve}
 	${miniserve} ./static --index index.html
 
 ${miniserve}:
 	cargo install miniserve
 
-static/wasm_bg.wasm: ${src}
+${wasm}: ${src}
 	${build}
 
 .PHONY: watch build_bg
 watch: build_bg serve
 
-build:
+build: ${wasm}
 	${build}
 
 build_local: FEATURES=--features local
+build_local: TARGET=--debug
 build_local: build


### PR DESCRIPTION
After trying a lot of stuff with `cargo chef` and different docker-caches, the so far simplest solution is this:
- compile using rust directly in the github-action
- copy everything into the docker-images

Every combination of `cargo chef` / `dummy.rs` with `whoan/docker-build-with-cache-action` / `satackey/action-docker-layer-caching` did have some downsides.