### PR TITLE
Detect more reliably if the DataChannel is open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
 update_version:
 	echo "pub const VERSION_STRING: &str = \"$$( date +%Y-%m-%d_%H:%M )::$$( git rev-parse --short HEAD )\";" > common/src/node/version.rs
+
+serve_local:
+	pkill -f signal
+	cargo build
+	cargo run --bin signal &
+	make -C wasm/web clean build_local serve &
+	make -C cli/flnode run2

--- a/common/src/node/logic.rs
+++ b/common/src/node/logic.rs
@@ -163,7 +163,7 @@ impl Logic {
             let cs = match st {
                 CSEnum::Idle => ConnState::Idle,
                 CSEnum::Setup => ConnState::Setup,
-                CSEnum::Connected => {
+                CSEnum::HasDataChannel => {
                     if let Some(state_value) = state {
                         match state_value.type_local {
                             crate::signal::web_rtc::ConnType::Unknown => ConnState::Connected,

--- a/common/src/node/network.rs
+++ b/common/src/node/network.rs
@@ -247,7 +247,7 @@ impl Network {
                 Arc::clone(&self.web_rtc),
                 self.process.clone(),
             )?);
-        conn.send(msg.clone())
+        conn.send(msg.clone()).await
     }
 
     pub fn clear_nodes(&mut self) -> Result<(), String> {

--- a/common/src/signal/web_rtc.rs
+++ b/common/src/signal/web_rtc.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use web_sys::{RtcIceConnectionState, RtcIceGatheringState};
+use web_sys::{RtcDataChannelState, RtcIceConnectionState, RtcIceGatheringState};
 
 use crate::{node::config::NodeInfo, types::U256};
 
@@ -81,8 +81,9 @@ pub struct ConnectionStateMap {
     pub type_local: ConnType,
     pub type_remote: ConnType,
     pub signaling: SignalingState,
-    pub gathering: RtcIceGatheringState,
-    pub connection: RtcIceConnectionState,
+    pub ice_gathering: RtcIceGatheringState,
+    pub ice_connection: RtcIceConnectionState,
+    pub data_connection: Option<RtcDataChannelState>,
     pub rx_bytes: u64,
     pub tx_bytes: u64,
     pub delay_ms: u32,

--- a/wasm/lib/src/web_rtc_connection.rs
+++ b/wasm/lib/src/web_rtc_connection.rs
@@ -43,7 +43,9 @@ impl WebRTCConnection for WebRTCConnectionWasm {
     }
 
     async fn get_state(&self) -> Result<ConnectionStateMap, String> {
-        get_state(self.conn.clone()).await
+        let mut csm = get_state(self.conn.clone()).await?;
+        csm.data_connection = Some(self.dc.ready_state());
+        Ok(csm)
     }
 }
 
@@ -74,8 +76,9 @@ pub async fn get_state(conn: RtcPeerConnection) -> Result<ConnectionStateMap, St
         _ => SignalingState::Setup,
     };
     Ok(ConnectionStateMap {
-        gathering: conn.ice_gathering_state(),
-        connection: conn.ice_connection_state(),
+        ice_gathering: conn.ice_gathering_state(),
+        ice_connection: conn.ice_connection_state(),
+        data_connection: None,
         signaling,
         delay_ms: 0,
         tx_bytes: 0,

--- a/wasm/web/Makefile
+++ b/wasm/web/Makefile
@@ -9,6 +9,9 @@ serve: TARGET := --debug
 serve: ${wasm} ${miniserve}
 	${miniserve} ./static --index index.html
 
+clean:
+	rm ${wasm}
+
 ${miniserve}:
 	cargo install miniserve
 

--- a/wasm/web/src/lib.rs
+++ b/wasm/web/src/lib.rs
@@ -68,7 +68,7 @@ impl Component for Model {
         match msg {
             Msg::Tick => {
                 self.counter += 1;
-                if self.counter % 5 == 0 || self.counter < 5 {
+                if self.counter % 10 == 1 {
                     self.node_list();
                     self.node_ping();
                 }


### PR DESCRIPTION
With the slow 'process' messages, the detection of whether the
DataChannel can be used or not was flaky, but it didn't matter.
Now, with the callback-driven 'process', the DataChannel
opening can be outstanding while the node tries to send a
message through it.
So this PR makes sure the DataChannel is available AND
it is open.