### PR TITLE
Adding overlay to the modules

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -7,31 +7,11 @@
     },
     "darwin.apple_sdk.frameworks.Security": {
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#darwin.apple_sdk.frameworks.Security",
-      "source": "nixpkg",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "path": "/nix/store/9jbhn62ld50znjqxll0q5gq9i4disc1s-apple-framework-Security-11.0.0",
-              "default": true
-            }
-          ]
-        }
-      }
+      "source": "nixpkg"
     },
     "darwin.apple_sdk.frameworks.SystemConfiguration": {
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#darwin.apple_sdk.frameworks.SystemConfiguration",
-      "source": "nixpkg",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "path": "/nix/store/jaxmz1dvsz8il7nkxwzw8xfxac3sfz5v-apple-framework-SystemConfiguration-11.0.0",
-              "default": true
-            }
-          ]
-        }
-      }
+      "source": "nixpkg"
     },
     "git@latest": {
       "last_modified": "2024-08-14T11:41:26Z",

--- a/flmodules/README.md
+++ b/flmodules/README.md
@@ -24,6 +24,11 @@ mode - requesting list of available events from other nodes.
 the signalling server.
 - `web_proxy` allows sending a http GET request to another node, using the other
 node as a proxy.
+- `overlay` is an intermediate layer that contains all messages to be implemented
+for current and future communication layers. 
+Currently it's implemented for `random_connections` and `network`.
+Future implementations might include a `dht_router` and a `mix_net` communication
+layer.
 
 # Adding your own modules
 

--- a/flmodules/src/lib.rs
+++ b/flmodules/src/lib.rs
@@ -20,3 +20,4 @@ pub mod timer;
 pub mod ping;
 pub mod web_proxy;
 pub mod network;
+pub mod overlay;

--- a/flmodules/src/overlay/README.md
+++ b/flmodules/src/overlay/README.md
@@ -1,0 +1,13 @@
+# Overlay
+
+Gives an abstraction to allow for different network overlays, e.g., random_connections, dht_network, loopix, and
+others. It defines a basic set of messages and a broker, which can then be extended to work with the different
+network connection modules.
+
+Two examples are implemented:
+- `OverlayRandom` uses the `RandomConnection` broker to handle the network and forwards messages as appropriate
+- `OverlayDirect` uses the `Network` broker to handle the network. One problem with this is that the `Connected`
+and `Disconnected` messages from the `Network` broker need to be handled here.
+
+To implement a new example who has the `Available`, `Connected`, `Disconnected` messages, the simplest way is to
+copy `OverlayRandom` into a new broker.

--- a/flmodules/src/overlay/broker.rs
+++ b/flmodules/src/overlay/broker.rs
@@ -33,7 +33,7 @@ impl OverlayRandom {
                             OverlayOut::NodeInfosConnected(infos)
                         }
                         RandomOut::NodeMessageFromNetwork(id, module_message) => {
-                            OverlayOut::NodeMessageFromNetwork(id, module_message)
+                            OverlayOut::NetworkMapperFromNetwork(id, module_message)
                         }
                         _ => return None,
                     };
@@ -44,7 +44,7 @@ impl OverlayRandom {
             Box::new(|msg| {
                 if let OverlayMessage::Input(input) = msg {
                     let ret = match input {
-                        OverlayIn::NodeMessageToNetwork(id, module_message) => {
+                        OverlayIn::NetworkWrapperToNetwork(id, module_message) => {
                             RandomIn::NodeMessageToNetwork(id, module_message)
                         }
                     };
@@ -91,7 +91,7 @@ impl OverlayDirect {
                     return match out {
                         NetworkOut::RcvNodeMessage(id, msg_str) => {
                             serde_yaml::from_str(&msg_str).ok().map(|module_message| {
-                                OverlayOut::NodeMessageFromNetwork(id, module_message).into()
+                                OverlayOut::NetworkMapperFromNetwork(id, module_message).into()
                             })
                         }
                         NetworkOut::RcvWSUpdateList(vec) => {
@@ -109,7 +109,7 @@ impl OverlayDirect {
             Box::new(|msg| {
                 if let OverlayMessage::Input(input) = msg {
                     let ret = match input {
-                        OverlayIn::NodeMessageToNetwork(id, module_message) => {
+                        OverlayIn::NetworkWrapperToNetwork(id, module_message) => {
                             if let Ok(msg_str) = serde_yaml::to_string(&module_message) {
                                 NetworkIn::SendNodeMessage(id, msg_str)
                             } else {

--- a/flmodules/src/overlay/broker.rs
+++ b/flmodules/src/overlay/broker.rs
@@ -1,0 +1,288 @@
+use flarch::{
+    broker::{Broker, BrokerError, Subsystem, SubsystemHandler},
+    nodeids::U256,
+    platform_async_trait,
+};
+
+use super::messages::{OverlayIn, OverlayInternal, OverlayMessage, OverlayOut};
+use crate::{
+    network::messages::{NetworkIn, NetworkMessage, NetworkOut},
+    nodeconfig::NodeInfo,
+    random_connections::messages::{RandomIn, RandomMessage, RandomOut},
+};
+
+pub struct OverlayRandom {}
+
+impl OverlayRandom {
+    pub async fn start(
+        random: Broker<RandomMessage>,
+    ) -> Result<Broker<OverlayMessage>, BrokerError> {
+        let mut b = Broker::new();
+        // Translate RandomOut to OverlayOut, and OverlayIn to RandomIn.
+        // A module connected to the Broker<OverlayMessage> will get translations of the
+        // RandomOut messages, and can send messages to RandomIn using the Overlay.
+        b.link_bi(
+            random,
+            Box::new(|msg| {
+                if let RandomMessage::Output(out) = msg {
+                    let ret = match out {
+                        RandomOut::NodeIDsConnected(node_ids) => {
+                            OverlayOut::NodeIDsConnected(node_ids)
+                        }
+                        RandomOut::NodeInfosConnected(infos) => {
+                            OverlayOut::NodeInfosConnected(infos)
+                        }
+                        RandomOut::NodeMessageFromNetwork(id, module_message) => {
+                            OverlayOut::NodeMessageFromNetwork(id, module_message)
+                        }
+                        _ => return None,
+                    };
+                    return Some(ret.into());
+                }
+                None
+            }),
+            Box::new(|msg| {
+                if let OverlayMessage::Input(input) = msg {
+                    let ret = match input {
+                        OverlayIn::NodeMessageToNetwork(id, module_message) => {
+                            RandomIn::NodeMessageToNetwork(id, module_message)
+                        }
+                    };
+                    return Some(RandomMessage::Input(ret));
+                }
+                None
+            }),
+        )
+        .await?;
+        Ok(b)
+    }
+}
+
+/**
+ * Connects directly to the Network broker.
+ * Because the Network broker only delivers 'Connected' and 'Disconnected'
+ * messages, this implementation has to do some bookkeeping to send out
+ * the correct messages.
+ */
+pub struct OverlayDirect {
+    nodes_available: Vec<NodeInfo>,
+    nodes_connected: Vec<U256>,
+}
+
+impl OverlayDirect {
+    pub async fn start(
+        direct: Broker<NetworkMessage>,
+    ) -> Result<Broker<OverlayMessage>, BrokerError> {
+        let mut b = Broker::new();
+        // Subsystem for handling Connected and Disconnected messages from the Network broker.
+        b.add_subsystem(Subsystem::Handler(Box::new(OverlayDirect {
+            nodes_available: vec![],
+            nodes_connected: vec![],
+        })))
+        .await?;
+
+        // Translate NetworkOut to OverlayOut, and OverlayIn to NetworkIn.
+        // A module connected to the Broker<OverlayMessage> will get translations of the
+        // NetworkOut messages, and can send messages to NetworkIn using the Overlay.
+        b.link_bi(
+            direct,
+            Box::new(|msg| {
+                if let NetworkMessage::Output(out) = msg {
+                    return match out {
+                        NetworkOut::RcvNodeMessage(id, msg_str) => {
+                            serde_yaml::from_str(&msg_str).ok().map(|module_message| {
+                                OverlayOut::NodeMessageFromNetwork(id, module_message).into()
+                            })
+                        }
+                        NetworkOut::RcvWSUpdateList(vec) => {
+                            Some(OverlayInternal::Available(vec).into())
+                        }
+                        NetworkOut::Connected(id) => Some(OverlayInternal::Connected(id).into()),
+                        NetworkOut::Disconnected(id) => {
+                            Some(OverlayInternal::Disconnected(id).into())
+                        }
+                        _ => None,
+                    };
+                }
+                None
+            }),
+            Box::new(|msg| {
+                if let OverlayMessage::Input(input) = msg {
+                    let ret = match input {
+                        OverlayIn::NodeMessageToNetwork(id, module_message) => {
+                            if let Ok(msg_str) = serde_yaml::to_string(&module_message) {
+                                NetworkIn::SendNodeMessage(id, msg_str)
+                            } else {
+                                return None;
+                            }
+                        }
+                    };
+                    return Some(NetworkMessage::Input(ret));
+                }
+                None
+            }),
+        )
+        .await?;
+        Ok(b)
+    }
+
+    fn available_connected(&self, id: U256) -> (bool, bool) {
+        (
+            self.nodes_available
+                .iter()
+                .find(|info| info.get_id() == id)
+                .is_some(),
+            self.nodes_connected.contains(&id),
+        )
+    }
+}
+
+#[platform_async_trait()]
+impl SubsystemHandler<OverlayMessage> for OverlayDirect {
+    async fn messages(&mut self, msgs: Vec<OverlayMessage>) -> Vec<OverlayMessage> {
+        let mut ret = false;
+        // Keep track of available and connected / disconnected nodes.
+        for msg in msgs {
+            if let OverlayMessage::Internal(internal) = msg {
+                match internal {
+                    OverlayInternal::Connected(id) => {
+                        if self.available_connected(id) == (true, false) {
+                            self.nodes_connected.push(id);
+                            ret = true;
+                        }
+                    }
+                    OverlayInternal::Disconnected(id) => {
+                        if self.available_connected(id).1 == true {
+                            self.nodes_connected.retain(|&other| other != id);
+                            ret = true;
+                        }
+                    }
+                    OverlayInternal::Available(vec) => {
+                        self.nodes_available = vec;
+                        ret = true;
+                    }
+                }
+            }
+        }
+
+        // If something changed, output all relevant messages.
+        if ret {
+            vec![
+                OverlayOut::NodeInfoAvailable(self.nodes_available.clone()),
+                OverlayOut::NodeIDsConnected(self.nodes_connected.clone().into()),
+                OverlayOut::NodeInfosConnected(
+                    self.nodes_available
+                        .iter()
+                        .filter(|node| self.nodes_connected.contains(&node.get_id()))
+                        .cloned()
+                        .collect(),
+                ),
+            ]
+            .into_iter()
+            .map(|msg| msg.into())
+            .collect()
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use flarch::nodeids::NodeID;
+
+    use crate::nodeconfig::NodeConfig;
+
+    use super::*;
+
+    fn check_msgs(msgs: Vec<OverlayMessage>, available: &[NodeInfo], connected: &[NodeInfo]) {
+        assert_eq!(3, msgs.len());
+        assert_eq!(
+            OverlayMessage::Output(OverlayOut::NodeInfoAvailable(available.to_vec())),
+            msgs[0]
+        );
+        assert_eq!(
+            OverlayMessage::Output(OverlayOut::NodeIDsConnected(
+                connected
+                    .iter()
+                    .map(|info| info.get_id())
+                    .collect::<Vec<NodeID>>()
+                    .into()
+            )),
+            msgs[1]
+        );
+        assert_eq!(
+            OverlayMessage::Output(OverlayOut::NodeInfosConnected(connected.to_vec())),
+            msgs[2]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_direct_dis_connect() -> Result<(), BrokerError> {
+        let mut od = OverlayDirect {
+            nodes_available: vec![],
+            nodes_connected: vec![],
+        };
+        let nodes = [NodeConfig::new().info, NodeConfig::new().info];
+        let node_unknown = NodeConfig::new().info.get_id();
+
+        // Start with two new nodes, but not yet connected.
+        let msgs = od
+            .messages(vec![OverlayInternal::Available(vec![
+                nodes[0].clone(),
+                nodes[1].clone(),
+            ])
+            .into()])
+            .await;
+        check_msgs(msgs, &nodes, &[]);
+
+        // Connect first node 0, then node 1
+        let msgs = od
+            .messages(vec![OverlayInternal::Connected(nodes[0].get_id()).into()])
+            .await;
+        check_msgs(msgs, &nodes, &[nodes[0].clone()]);
+
+        let msgs = od
+            .messages(vec![OverlayInternal::Connected(nodes[1].get_id()).into()])
+            .await;
+        check_msgs(msgs, &nodes, &nodes);
+
+        // Re-connect node 1, should do nothing
+        let msgs = od
+            .messages(vec![OverlayInternal::Connected(nodes[1].get_id()).into()])
+            .await;
+        assert_eq!(0, msgs.len());
+
+        // Connect an unknown node - this should be ignored
+        let msgs = od
+            .messages(vec![OverlayInternal::Connected(node_unknown).into()])
+            .await;
+        assert_eq!(0, msgs.len());
+
+        // Disconnect an unknown node - twice, in case it keeps it and would fail to remove it when
+        // it isn't here anymore.
+        let msgs = od
+            .messages(vec![OverlayInternal::Disconnected(node_unknown).into()])
+            .await;
+        assert_eq!(0, msgs.len());
+
+        let msgs = od
+            .messages(vec![OverlayInternal::Disconnected(node_unknown).into()])
+            .await;
+        assert_eq!(0, msgs.len());
+
+        // Disconnect a node
+        let msgs = od
+            .messages(vec![OverlayInternal::Disconnected(nodes[0].get_id()).into()])
+            .await;
+        check_msgs(msgs, &nodes, &[nodes[1].clone()]);
+
+        // Disconnect an unconnected node
+        let msgs = od
+            .messages(vec![OverlayInternal::Disconnected(nodes[0].get_id()).into()])
+            .await;
+        assert_eq!(0, msgs.len());
+
+        Ok(())
+    }
+}

--- a/flmodules/src/overlay/messages.rs
+++ b/flmodules/src/overlay/messages.rs
@@ -1,0 +1,55 @@
+use flarch::nodeids::{NodeID, NodeIDs, U256};
+use serde::{Deserialize, Serialize};
+
+use crate::nodeconfig::NodeInfo;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModuleMessage {
+    pub module: String,
+    pub msg: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum OverlayMessage {
+    Input(OverlayIn),
+    Output(OverlayOut),
+    Internal(OverlayInternal),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum OverlayIn {
+    NodeMessageToNetwork(NodeID, ModuleMessage),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum OverlayOut {
+    NodeInfoAvailable(Vec<NodeInfo>),
+    NodeIDsConnected(NodeIDs),
+    NodeInfosConnected(Vec<NodeInfo>),
+    NodeMessageFromNetwork(NodeID, ModuleMessage),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum OverlayInternal {
+    Connected(U256),
+    Disconnected(U256),
+    Available(Vec<NodeInfo>),
+}
+
+impl From<OverlayOut> for OverlayMessage {
+    fn from(value: OverlayOut) -> Self {
+        OverlayMessage::Output(value)
+    }
+}
+
+impl From<OverlayIn> for OverlayMessage {
+    fn from(value: OverlayIn) -> Self {
+        OverlayMessage::Input(value)
+    }
+}
+
+impl From<OverlayInternal> for OverlayMessage {
+    fn from(value: OverlayInternal) -> Self {
+        OverlayMessage::Internal(value)
+    }
+}

--- a/flmodules/src/overlay/mod.rs
+++ b/flmodules/src/overlay/mod.rs
@@ -1,0 +1,2 @@
+pub mod broker;
+pub mod messages;

--- a/flmodules/src/ping/broker.rs
+++ b/flmodules/src/ping/broker.rs
@@ -6,8 +6,7 @@ use flarch::{
 };
 
 use crate::{
-    random_connections::messages::{ModuleMessage, RandomIn, RandomMessage, RandomOut},
-    timer::TimerMessage,
+    overlay::messages::ModuleMessage, random_connections::messages::{RandomIn, RandomMessage, RandomOut}, timer::TimerMessage
 };
 
 use super::{
@@ -89,7 +88,7 @@ impl Translate {
         if let RandomMessage::Output(msg_out) = msg {
             match msg_out {
                 RandomOut::DisconnectNode(id) => Some(PingIn::DisconnectNode(id).into()),
-                RandomOut::ListUpdate(list) => Some(PingIn::NodeList(list.into()).into()),
+                RandomOut::NodeIDsConnected(list) => Some(PingIn::NodeList(list.into()).into()),
                 RandomOut::NodeMessageFromNetwork(id, msg) => {
                     if msg.module == MODULE_NAME {
                         serde_yaml::from_str::<MessageNode>(&msg.msg)

--- a/flmodules/src/random_connections/messages.rs
+++ b/flmodules/src/random_connections/messages.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use flarch::nodeids::{NodeID, NodeIDs, U256};
 
-use crate::nodeconfig::NodeInfo;
+use crate::{nodeconfig::NodeInfo, overlay::messages::ModuleMessage};
 
 use super::core::RandomStorage;
 
@@ -11,12 +11,6 @@ use super::core::RandomStorage;
 pub enum NodeMessage {
     Module(ModuleMessage),
     DropConnection,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ModuleMessage {
-    pub module: String,
-    pub msg: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -40,8 +34,8 @@ pub enum RandomIn {
 pub enum RandomOut {
     ConnectNode(NodeID),
     DisconnectNode(NodeID),
-    ListUpdate(NodeIDs),
-    NodeInfoConnected(Vec<NodeInfo>),
+    NodeIDsConnected(NodeIDs),
+    NodeInfosConnected(Vec<NodeInfo>),
     NodeMessageToNetwork(NodeID, NodeMessage),
     NodeMessageFromNetwork(NodeID, ModuleMessage),
     Storage(RandomStorage),
@@ -113,7 +107,7 @@ impl RandomConnections {
                     );
                     vec![
                         RandomOut::DisconnectNode(dst),
-                        RandomOut::ListUpdate(self.storage.connected.get_nodes()),
+                        RandomOut::NodeIDsConnected(self.storage.connected.get_nodes()),
                     ]
                 }
             }
@@ -200,8 +194,8 @@ impl RandomConnections {
 
     fn update(&self) -> Vec<RandomOut> {
         vec![
-            RandomOut::ListUpdate(self.storage.connected.get_nodes()),
-            RandomOut::NodeInfoConnected(self.storage.get_connected_info()),
+            RandomOut::NodeIDsConnected(self.storage.connected.get_nodes()),
+            RandomOut::NodeInfosConnected(self.storage.get_connected_info()),
             RandomOut::Storage(self.storage.clone()),
         ]
     }

--- a/flmodules/src/random_connections/messages.rs
+++ b/flmodules/src/random_connections/messages.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 
 use flarch::nodeids::{NodeID, NodeIDs, U256};
 
-use crate::{nodeconfig::NodeInfo, overlay::messages::ModuleMessage};
+use crate::{nodeconfig::NodeInfo, overlay::messages::NetworkWrapper};
 
 use super::core::RandomStorage;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum NodeMessage {
-    Module(ModuleMessage),
+    Module(NetworkWrapper),
     DropConnection,
 }
 
@@ -26,7 +26,7 @@ pub enum RandomIn {
     NodeConnected(NodeID),
     NodeDisconnected(NodeID),
     NodeMessageFromNetwork(NodeID, NodeMessage),
-    NodeMessageToNetwork(NodeID, ModuleMessage),
+    NodeMessageToNetwork(NodeID, NetworkWrapper),
     Tick,
 }
 
@@ -37,7 +37,7 @@ pub enum RandomOut {
     NodeIDsConnected(NodeIDs),
     NodeInfosConnected(Vec<NodeInfo>),
     NodeMessageToNetwork(NodeID, NodeMessage),
-    NodeMessageFromNetwork(NodeID, ModuleMessage),
+    NodeMessageFromNetwork(NodeID, NetworkWrapper),
     Storage(RandomStorage),
 }
 

--- a/flnode/src/node.rs
+++ b/flnode/src/node.rs
@@ -15,17 +15,10 @@ use flmodules::{
         broker::GossipBroker,
         core::{self, Category, Event},
         messages::{GossipIn, GossipMessage},
-    },
-    network::messages::{NetworkIn, NetworkError, NetworkMessage},
-    nodeconfig::{ConfigError, NodeConfig, NodeInfo},
-    ping::{broker::PingBroker, messages::PingConfig},
-    random_connections::broker::RandomBroker,
-    timer::{TimerBroker, TimerMessage},
-    web_proxy::{
+    }, network::messages::{NetworkError, NetworkIn, NetworkMessage}, nodeconfig::{ConfigError, NodeConfig, NodeInfo}, overlay::broker::OverlayRandom, ping::{broker::PingBroker, messages::PingConfig}, random_connections::broker::RandomBroker, timer::{TimerBroker, TimerMessage}, web_proxy::{
         broker::{WebProxy, WebProxyError},
         core::WebProxyConfig,
-    },
-    Modules,
+    }, Modules
 };
 
 use crate::stat::StatBroker;
@@ -116,7 +109,7 @@ impl Node {
                     WebProxy::start(
                         storage.clone(),
                         id,
-                        rnd.broker.clone(),
+                        OverlayRandom::start(rnd.broker.clone()).await?,
                         WebProxyConfig::default(),
                     )
                     .await?,


### PR DESCRIPTION
Before this the system relied on random_connections to communicate between nodes. But random_connections is but one implementation of the connection handling in fledger, new ones will join hopefully soon:
- dht_routing - create a routing-table based on a DHT
- mix_net - use loopix service nodes as endpoints