### PR TITLE
Renaming messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Following https://keepachangelog.com/en/1.1.0/ and using
 - re-arranged file names in the flmodules section, to better fit with the `template` module
 - changed the names of the networking messages
 - added an `Overlay` module to abstract the network handling
+- more changes in names of the messages to remove ambiguities
 
 ## [0.8.0] - 2024-09-09
 

--- a/examples/ping-pong/shared/src/event_loop.rs
+++ b/examples/ping-pong/shared/src/event_loop.rs
@@ -59,10 +59,10 @@ fn update_list(
     net: &mut Broker<NetworkMessage>,
     nodes: &Vec<NodeInfo>,
 ) -> Result<(), BrokerError> {
-    net.emit_msg(NetworkMessage::Input(NetworkIn::SendWSUpdateListRequest))?;
+    net.emit_msg(NetworkMessage::Input(NetworkIn::WSUpdateListRequest))?;
     for node in nodes.iter() {
         if node.get_id() != id {
-            net.emit_msg(NetworkMessage::Input(NetworkIn::SendNodeMessage(
+            net.emit_msg(NetworkMessage::Input(NetworkIn::MessageToNode(
                 node.get_id(),
                 serde_json::to_string(&PPMessageNode::Ping).unwrap(),
             )))?;
@@ -79,18 +79,18 @@ fn new_msg(
 ) -> Result<Option<Vec<NodeInfo>>, BrokerError> {
     if let Some(NetworkMessage::Output(msg_tap)) = msg {
         match msg_tap {
-            NetworkOut::RcvNodeMessage(from, msg_net) => {
+            NetworkOut::MessageFromNode(from, msg_net) => {
                 if let Ok(msg) = serde_json::from_str::<PPMessageNode>(&msg_net) {
                     ret.emit_msg(PPMessage::FromNetwork(from, msg.clone()))?;
                     if msg == PPMessageNode::Ping {
-                        net.emit_msg(NetworkMessage::Input(NetworkIn::SendNodeMessage(
+                        net.emit_msg(NetworkMessage::Input(NetworkIn::MessageToNode(
                             from,
                             serde_json::to_string(&PPMessageNode::Pong).unwrap(),
                         )))?;
                     }
                 }
             }
-            NetworkOut::RcvWSUpdateList(list) => {
+            NetworkOut::NodeListFromWS(list) => {
                 ret.emit_msg(PPMessage::List(list.clone()))?;
                 return Ok(Some(list));
             }

--- a/examples/ping-pong/shared/src/handler.rs
+++ b/examples/ping-pong/shared/src/handler.rs
@@ -60,19 +60,19 @@ impl PingPong {
     }
 
     // Translates incoming messages from the network to messages that can be understood by PingPong.
-    // The only two messages that need to be interpreted are RcvNodeMessage and RcvWSUpdateList.
-    // For RcvNodeMessage, the enclosed message is interpreted as a PPMessageNode and sent to this
+    // The only two messages that need to be interpreted are MessageFromNode and NodeListFromWS.
+    // For MessageFromNode, the enclosed message is interpreted as a PPMessageNode and sent to this
     // broker.
     // All other messages coming from Network are ignored.
     fn net_to_pp(msg: NetworkMessage) -> Option<PPMessage> {
         if let NetworkMessage::Output(rep) = msg {
             match rep {
-                NetworkOut::RcvNodeMessage(from, node_msg) => {
+                NetworkOut::MessageFromNode(from, node_msg) => {
                     serde_json::from_str::<PPMessageNode>(&node_msg)
                         .ok()
                         .map(|ppm| PPMessage::FromNetwork(from, ppm))
                 }
-                NetworkOut::RcvWSUpdateList(nodes) => Some(PPMessage::List(nodes)),
+                NetworkOut::NodeListFromWS(nodes) => Some(PPMessage::List(nodes)),
                 _ => None,
             }
         } else {
@@ -91,7 +91,7 @@ impl PingPong {
     // Wraps a PPMessageNode into a json and sends it over the network to the
     // dst address.
     async fn send_net_ppm(&mut self, dst: U256, msg: &PPMessageNode) {
-        self.send_net(NetworkIn::SendNodeMessage(
+        self.send_net(NetworkIn::MessageToNode(
             dst,
             serde_json::to_string(msg).unwrap(),
         ))
@@ -115,7 +115,7 @@ impl SubsystemHandler<PPMessage> for PingPong {
                 }
                 PPMessage::FromNetwork(from, PPMessageNode::Ping) => {
                     self.send_net_ppm(from, &PPMessageNode::Pong).await;
-                    self.send_net(NetworkIn::SendWSUpdateListRequest).await;
+                    self.send_net(NetworkIn::WSUpdateListRequest).await;
                 }
                 PPMessage::List(list) => self.nodes = list,
                 PPMessage::Tick => {
@@ -185,7 +185,7 @@ mod test {
         // Receive a ping message through the network
         net.emit_msg_dest(
             Destination::NoTap,
-            NetworkMessage::Output(NetworkOut::RcvNodeMessage(
+            NetworkMessage::Output(NetworkOut::MessageFromNode(
                 dst_id.clone(),
                 serde_json::to_string(&PPMessageNode::Ping).unwrap(),
             )),
@@ -199,7 +199,7 @@ mod test {
             net_tap.recv().unwrap()
         );
         assert_eq!(
-            NetworkMessage::Input(NetworkIn::SendWSUpdateListRequest),
+            NetworkMessage::Input(NetworkIn::WSUpdateListRequest),
             net_tap.recv().unwrap()
         );
 
@@ -207,7 +207,7 @@ mod test {
     }
 
     fn node_msg(dst: &U256, msg: &PPMessageNode) -> NetworkMessage {
-        NetworkMessage::Input(NetworkIn::SendNodeMessage(
+        NetworkMessage::Input(NetworkIn::MessageToNode(
             dst.clone(),
             serde_json::to_string(msg).unwrap(),
         ))

--- a/examples/ping/src/main.rs
+++ b/examples/ping/src/main.rs
@@ -61,9 +61,9 @@ async fn ping() -> Result<(), BrokerError> {
             msg = net.recv() => {
                     match msg {
                         // Display the messages received
-                        NetworkOut::RcvNodeMessage(from, msg) => log::info!("Got message {msg:?} from node {from}"),
+                        NetworkOut::MessageFromNode(from, msg) => log::info!("Got message {msg:?} from node {from}"),
                         // If a new list is available, ping all nodes in the list
-                        NetworkOut::RcvWSUpdateList(list) => for node in list {
+                        NetworkOut::NodeListFromWS(list) => for node in list {
                             if node.get_id() != nc.info.get_id() {
                                 // Sends a text message to the 'node' if it's not ourselves
                                 net.send_msg(node.get_id(), "Ping".into())?
@@ -113,7 +113,7 @@ async fn client(server_id: &str) -> Result<(), BrokerError> {
     log::info!("Server id is {server_id:?}");
     // This sends the message by setting up a connection using the signalling server.
     // The client must already be running and be registered with the signalling server.
-    // Using `SendNodeMessage` will set up a connection using the signalling server, but
+    // Using `MessageToNode` will set up a connection using the signalling server, but
     // in the best case, the signalling server will not be used anymore afterwards.
     net.send_msg(server_id, "ping".into())?;
 

--- a/flmodules/src/gossip_events/broker.rs
+++ b/flmodules/src/gossip_events/broker.rs
@@ -119,9 +119,9 @@ impl Translate {
         if let RandomMessage::Output(msg_out) = msg {
             match msg_out {
                 RandomOut::NodeIDsConnected(list) => Some(GossipIn::NodeList(list.into()).into()),
-                RandomOut::NodeMessageFromNetwork(id, msg) => msg
+                RandomOut::NetworkWrapperFromNetwork(id, msg) => msg
                     .unwrap_yaml(MODULE_NAME)
-                    .map(|msg| GossipIn::Node(id, msg).into()),
+                    .map(|msg| GossipIn::FromNetwork(id, msg).into()),
                 _ => None,
             }
         } else {
@@ -130,9 +130,9 @@ impl Translate {
     }
 
     fn link_gossip_rnd(msg: GossipMessage) -> Option<RandomMessage> {
-        if let GossipMessage::Output(GossipOut::Node(id, msg_node)) = msg {
+        if let GossipMessage::Output(GossipOut::ToNetwork(id, msg_node)) = msg {
             Some(
-                RandomIn::NodeMessageToNetwork(
+                RandomIn::NetworkMapperToNetwork(
                     id,
                     NetworkWrapper::wrap_yaml(MODULE_NAME, &msg_node).unwrap(),
                 )
@@ -184,7 +184,7 @@ mod tests {
     use std::error::Error;
 
     use crate::gossip_events::core::{Category, Event};
-    use crate::gossip_events::messages::MessageNode;
+    use crate::gossip_events::messages::ModuleMessage;
     use flarch::nodeids::NodeID;
     use flarch::{start_logging, tasks::now};
 
@@ -213,10 +213,10 @@ mod tests {
             created: now(),
             msg: "test_msg".into(),
         };
-        let msg = MessageNode::Events(vec![event.clone()]);
+        let msg = ModuleMessage::Events(vec![event.clone()]);
         broker_rnd
             .settle_msg(
-                RandomOut::NodeMessageFromNetwork(
+                RandomOut::NetworkWrapperFromNetwork(
                     id2,
                     NetworkWrapper::wrap_yaml(MODULE_NAME, &msg).unwrap(),
                 )
@@ -233,11 +233,11 @@ mod tests {
 
     fn assert_msg_reid(tap: &Receiver<RandomMessage>, id2: &NodeID) -> Result<(), Box<dyn Error>> {
         for msg in tap.try_iter() {
-            if let RandomMessage::Input(RandomIn::NodeMessageToNetwork(id, msg_mod)) = msg {
+            if let RandomMessage::Input(RandomIn::NetworkMapperToNetwork(id, msg_mod)) = msg {
                 assert_eq!(id2, &id);
                 assert_eq!(MODULE_NAME.to_string(), msg_mod.module);
                 let msg_yaml = serde_yaml::from_str(&msg_mod.msg)?;
-                assert_eq!(MessageNode::RequestEventIDs, msg_yaml);
+                assert_eq!(ModuleMessage::RequestEventIDs, msg_yaml);
             } else {
                 assert!(false);
             }

--- a/flmodules/src/gossip_events/messages.rs
+++ b/flmodules/src/gossip_events/messages.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::core::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum MessageNode {
+pub enum ModuleMessage {
     KnownEventIDs(Vec<U256>),
     Events(Vec<Event>),
     RequestEventIDs,
@@ -20,7 +20,7 @@ pub enum GossipMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum GossipIn {
     Tick,
-    Node(NodeID, MessageNode),
+    FromNetwork(NodeID, ModuleMessage),
     SetStorage(EventsStorage),
     GetStorage,
     AddEvent(Event),
@@ -29,7 +29,7 @@ pub enum GossipIn {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum GossipOut {
-    Node(NodeID, MessageNode),
+    ToNetwork(NodeID, ModuleMessage),
     Storage(EventsStorage),
     Updated,
 }
@@ -86,7 +86,7 @@ impl GossipEvents {
         log::trace!("{} got message {:?}", self.cfg.our_id, msg);
         Ok(match msg {
             GossipIn::Tick => self.tick(),
-            GossipIn::Node(src, node_msg) => self.process_node_message(src, node_msg),
+            GossipIn::FromNetwork(src, node_msg) => self.process_node_message(src, node_msg),
             GossipIn::AddEvent(ev) => self.add_event(ev),
             GossipIn::NodeList(ids) => self.node_list(ids),
             GossipIn::GetStorage => vec![GossipOut::Storage(self.storage.clone())],
@@ -99,12 +99,12 @@ impl GossipEvents {
 
     /// Processes a node to node message and returns zero or more
     /// MessageOut.
-    pub fn process_node_message(&mut self, src: NodeID, msg: MessageNode) -> Vec<GossipOut> {
+    pub fn process_node_message(&mut self, src: NodeID, msg: ModuleMessage) -> Vec<GossipOut> {
         match msg {
-            MessageNode::KnownEventIDs(ids) => self.node_known_event_ids(src, ids),
-            MessageNode::Events(events) => self.node_events(src, events),
-            MessageNode::RequestEvents(ids) => self.node_request_events(src, ids),
-            MessageNode::RequestEventIDs => self.node_request_event_list(src),
+            ModuleMessage::KnownEventIDs(ids) => self.node_known_event_ids(src, ids),
+            ModuleMessage::Events(events) => self.node_events(src, events),
+            ModuleMessage::RequestEvents(ids) => self.node_request_events(src, ids),
+            ModuleMessage::RequestEventIDs => self.node_request_event_list(src),
         }
     }
 
@@ -136,9 +136,9 @@ impl GossipEvents {
             .iter()
             .filter(|&&node_id| node_id != src && node_id != self.cfg.our_id)
             .map(|node_id| {
-                GossipOut::Node(
+                GossipOut::ToNetwork(
                     *node_id,
-                    MessageNode::KnownEventIDs(
+                    ModuleMessage::KnownEventIDs(
                         events
                             .iter()
                             .filter_map(|e| {
@@ -162,7 +162,7 @@ impl GossipEvents {
             .0
             .iter()
             .filter(|&id| !self.nodes.0.contains(id) && id != &self.cfg.our_id)
-            .map(|&id| GossipOut::Node(id, MessageNode::RequestEventIDs))
+            .map(|&id| GossipOut::ToNetwork(id, ModuleMessage::RequestEventIDs))
             .collect();
         self.nodes = ids;
         reply
@@ -175,9 +175,9 @@ impl GossipEvents {
         let unknown_ids = self.filter_known_events(ids);
         if !unknown_ids.is_empty() {
             self.outstanding.extend(unknown_ids.clone());
-            return vec![GossipOut::Node(
+            return vec![GossipOut::ToNetwork(
                 src,
-                MessageNode::RequestEvents(unknown_ids),
+                ModuleMessage::RequestEvents(unknown_ids),
             )];
         }
         vec![]
@@ -204,7 +204,7 @@ impl GossipEvents {
     pub fn node_request_events(&mut self, src: NodeID, ids: Vec<U256>) -> Vec<GossipOut> {
         let events: Vec<Event> = self.storage.get_events_by_ids(ids);
         if !events.is_empty() {
-            vec![GossipOut::Node(src, MessageNode::Events(events))]
+            vec![GossipOut::ToNetwork(src, ModuleMessage::Events(events))]
         } else {
             vec![]
         }
@@ -212,9 +212,9 @@ impl GossipEvents {
 
     /// Returns the list of known events.
     pub fn node_request_event_list(&mut self, src: NodeID) -> Vec<GossipOut> {
-        vec![GossipOut::Node(
+        vec![GossipOut::ToNetwork(
             src,
-            MessageNode::KnownEventIDs(self.storage.event_ids()),
+            ModuleMessage::KnownEventIDs(self.storage.event_ids()),
         )]
     }
 
@@ -237,7 +237,7 @@ impl GossipEvents {
         self.nodes
             .0
             .iter()
-            .map(|id| GossipOut::Node(*id, MessageNode::RequestEventIDs))
+            .map(|id| GossipOut::ToNetwork(*id, ModuleMessage::RequestEventIDs))
             .collect()
     }
 }

--- a/flmodules/src/network/mod.rs
+++ b/flmodules/src/network/mod.rs
@@ -88,7 +88,7 @@
 //!     log::info!("Server id is {server_id:?}");
 //!     // This sends the message by setting up a connection using the signalling server.
 //!     // The client must already be running and be registered with the signalling server.
-//!     // Using `SendNodeMessage` will set up a connection using the signalling server, but
+//!     // Using `MessageToNode` will set up a connection using the signalling server, but
 //!     // in the best case, the signalling server will not be used anymore afterwards.
 //!     net.send_msg(server_id, "ping".into())?;
 //!

--- a/flmodules/src/network/testing.rs
+++ b/flmodules/src/network/testing.rs
@@ -73,16 +73,16 @@ impl NSHub {
     fn net_msg(&self, id: U256, net_msg: NetworkMessage) -> Vec<NSHubMessage> {
         if let NetworkMessage::Input(msg) = net_msg {
             match msg {
-                NetworkIn::SendNodeMessage(id_dst, msg_node) => {
+                NetworkIn::MessageToNode(id_dst, msg_node) => {
                     vec![NSHubMessage::ToClient(
                         id_dst,
-                        NetworkMessage::Output(NetworkOut::RcvNodeMessage(id, msg_node)),
+                        NetworkMessage::Output(NetworkOut::MessageFromNode(id, msg_node)),
                     )]
                 }
-                NetworkIn::SendWSUpdateListRequest => {
+                NetworkIn::WSUpdateListRequest => {
                     vec![NSHubMessage::ToClient(
                         id,
-                        NetworkMessage::Output(NetworkOut::RcvWSUpdateList(self.nodes.clone())),
+                        NetworkMessage::Output(NetworkOut::NodeListFromWS(self.nodes.clone())),
                     )]
                 }
                 _ => {

--- a/flmodules/src/overlay/broker.rs
+++ b/flmodules/src/overlay/broker.rs
@@ -32,7 +32,7 @@ impl OverlayRandom {
                         RandomOut::NodeInfosConnected(infos) => {
                             OverlayOut::NodeInfosConnected(infos)
                         }
-                        RandomOut::NodeMessageFromNetwork(id, module_message) => {
+                        RandomOut::NetworkWrapperFromNetwork(id, module_message) => {
                             OverlayOut::NetworkMapperFromNetwork(id, module_message)
                         }
                         _ => return None,
@@ -45,7 +45,7 @@ impl OverlayRandom {
                 if let OverlayMessage::Input(input) = msg {
                     let ret = match input {
                         OverlayIn::NetworkWrapperToNetwork(id, module_message) => {
-                            RandomIn::NodeMessageToNetwork(id, module_message)
+                            RandomIn::NetworkMapperToNetwork(id, module_message)
                         }
                     };
                     return Some(RandomMessage::Input(ret));
@@ -89,12 +89,12 @@ impl OverlayDirect {
             Box::new(|msg| {
                 if let NetworkMessage::Output(out) = msg {
                     return match out {
-                        NetworkOut::RcvNodeMessage(id, msg_str) => {
+                        NetworkOut::MessageFromNode(id, msg_str) => {
                             serde_yaml::from_str(&msg_str).ok().map(|module_message| {
                                 OverlayOut::NetworkMapperFromNetwork(id, module_message).into()
                             })
                         }
-                        NetworkOut::RcvWSUpdateList(vec) => {
+                        NetworkOut::NodeListFromWS(vec) => {
                             Some(OverlayInternal::Available(vec).into())
                         }
                         NetworkOut::Connected(id) => Some(OverlayInternal::Connected(id).into()),
@@ -111,7 +111,7 @@ impl OverlayDirect {
                     let ret = match input {
                         OverlayIn::NetworkWrapperToNetwork(id, module_message) => {
                             if let Ok(msg_str) = serde_yaml::to_string(&module_message) {
-                                NetworkIn::SendNodeMessage(id, msg_str)
+                                NetworkIn::MessageToNode(id, msg_str)
                             } else {
                                 return None;
                             }

--- a/flmodules/src/ping/broker.rs
+++ b/flmodules/src/ping/broker.rs
@@ -91,9 +91,9 @@ impl Translate {
             match msg_out {
                 RandomOut::DisconnectNode(id) => Some(PingIn::DisconnectNode(id).into()),
                 RandomOut::NodeIDsConnected(list) => Some(PingIn::NodeList(list.into()).into()),
-                RandomOut::NodeMessageFromNetwork(id, msg) => msg
+                RandomOut::NetworkWrapperFromNetwork(id, msg) => msg
                     .unwrap_yaml(MODULE_NAME)
-                    .map(|msg| PingIn::Message(id, msg).into()),
+                    .map(|msg| PingIn::FromNetwork(id, msg).into()),
                 _ => None,
             }
         } else {
@@ -104,8 +104,8 @@ impl Translate {
     fn link_ping_rnd(msg: PingMessage) -> Option<RandomMessage> {
         if let PingMessage::Output(msg_out) = msg {
             match msg_out {
-                PingOut::Message(id, msg_node) => Some(
-                    RandomIn::NodeMessageToNetwork(
+                PingOut::ToNetwork(id, msg_node) => Some(
+                    RandomIn::NetworkMapperToNetwork(
                         id,
                         NetworkWrapper::wrap_yaml(MODULE_NAME, &msg_node).unwrap(),
                     )

--- a/flmodules/src/ping/messages.rs
+++ b/flmodules/src/ping/messages.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::core::PingStorage;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum MessageNode {
+pub enum ModuleMessage {
     Ping,
     Pong,
 }
@@ -18,14 +18,14 @@ pub enum PingMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum PingIn {
     Tick,
-    Message(NodeID, MessageNode),
+    FromNetwork(NodeID, ModuleMessage),
     NodeList(NodeIDs),
     DisconnectNode(NodeID),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum PingOut {
-    Message(NodeID, MessageNode),
+    ToNetwork(NodeID, ModuleMessage),
     Storage(PingStorage),
     Failed(NodeID),
 }
@@ -52,7 +52,7 @@ impl Ping {
     pub fn process_msg(&mut self, msg: PingIn) -> Vec<PingOut> {
         match msg {
             PingIn::Tick => self.tick(),
-            PingIn::Message(id, msg_node) => self.message(id, msg_node),
+            PingIn::FromNetwork(id, msg_node) => self.message(id, msg_node),
             PingIn::NodeList(ids) => self.new_nodes(ids),
             PingIn::DisconnectNode(id) => {
                 self.storage.remove_node(&id);
@@ -69,12 +69,12 @@ impl Ping {
         ])
     }
 
-    pub fn message(&mut self, id: NodeID, msg: MessageNode) -> Vec<PingOut> {
+    pub fn message(&mut self, id: NodeID, msg: ModuleMessage) -> Vec<PingOut> {
         match msg {
-            MessageNode::Ping => {
-                vec![PingOut::Message(id, MessageNode::Pong)]
+            ModuleMessage::Ping => {
+                vec![PingOut::ToNetwork(id, ModuleMessage::Pong)]
             }
-            MessageNode::Pong => {
+            ModuleMessage::Pong => {
                 self.storage.pong(id);
                 self.create_messages()
             }
@@ -91,7 +91,7 @@ impl Ping {
     fn create_messages(&mut self) -> Vec<PingOut> {
         let mut out = vec![];
         for id in self.storage.ping.drain(..) {
-            out.push(PingOut::Message(id, MessageNode::Ping).into());
+            out.push(PingOut::ToNetwork(id, ModuleMessage::Ping).into());
         }
         for id in self.storage.failed.drain(..) {
             out.push(PingOut::Failed(id).into());

--- a/flmodules/src/template/broker.rs
+++ b/flmodules/src/template/broker.rs
@@ -13,7 +13,7 @@ use flarch::{
 
 use super::{
     core::{TemplateConfig, TemplateStorage, TemplateStorageSave},
-    messages::{MessageNode, TemplateIn, TemplateMessage, TemplateMessages, TemplateOut},
+    messages::{ModuleMessage, TemplateIn, TemplateMessage, TemplateMessages, TemplateOut},
 };
 
 const MODULE_NAME: &str = "Template";
@@ -67,7 +67,7 @@ impl Template {
 
     pub fn increase_self(&mut self, counter: u32) -> Result<(), BrokerError> {
         self.broker
-            .emit_msg(TemplateIn::Node(self.our_id, MessageNode::Increase(counter)).into())
+            .emit_msg(TemplateIn::FromNetwork(self.our_id, ModuleMessage::Increase(counter)).into())
     }
 
     pub fn get_counter(&self) -> u32 {
@@ -106,9 +106,9 @@ impl Translate {
                 RandomOut::NodeIDsConnected(list) => {
                     Some(TemplateIn::UpdateNodeList(list.into()).into())
                 }
-                RandomOut::NodeMessageFromNetwork(id, msg) => msg
+                RandomOut::NetworkWrapperFromNetwork(id, msg) => msg
                     .unwrap_yaml(MODULE_NAME)
-                    .map(|msg| TemplateIn::Node(id, msg).into()),
+                    .map(|msg| TemplateIn::FromNetwork(id, msg).into()),
                 _ => None,
             }
         } else {
@@ -117,9 +117,9 @@ impl Translate {
     }
 
     fn link_template_rnd(msg: TemplateMessage) -> Option<RandomMessage> {
-        if let TemplateMessage::Output(TemplateOut::Node(id, msg_node)) = msg {
+        if let TemplateMessage::Output(TemplateOut::ToNetwork(id, msg_node)) = msg {
             Some(
-                RandomIn::NodeMessageToNetwork(
+                RandomIn::NetworkMapperToNetwork(
                     id,
                     NetworkWrapper::wrap_yaml(MODULE_NAME, &msg_node).unwrap(),
                 )

--- a/flmodules/src/web_proxy/broker.rs
+++ b/flmodules/src/web_proxy/broker.rs
@@ -136,7 +136,7 @@ impl Translate {
                 }
                 OverlayOut::NetworkMapperFromNetwork(id, msg) => msg
                     .unwrap_yaml(MODULE_NAME)
-                    .map(|msg| WebProxyIn::Node(id, msg).into()),
+                    .map(|msg| WebProxyIn::FromNetwork(id, msg).into()),
                 _ => None,
             }
         } else {
@@ -145,7 +145,7 @@ impl Translate {
     }
 
     fn link_proxy_overlay(msg: WebProxyMessage) -> Option<OverlayMessage> {
-        if let WebProxyMessage::Output(WebProxyOut::Node(id, msg_node)) = msg {
+        if let WebProxyMessage::Output(WebProxyOut::ToNetwork(id, msg_node)) = msg {
             Some(
                 OverlayIn::NetworkWrapperToNetwork(
                     id,

--- a/flmodules/tests/load.rs
+++ b/flmodules/tests/load.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use flarch::{nodeids::NodeID, start_logging};
 use flmodules::gossip_events::{
     core::{Category, EventsStorage},
-    messages::{Config, GossipEvents, GossipIn, GossipOut, MessageNode},
+    messages::{Config, GossipEvents, GossipIn, GossipOut, ModuleMessage},
 };
 
 #[tokio::test]
@@ -26,7 +26,7 @@ async fn test_gossip() -> Result<(), Box<dyn Error>> {
     let msg12 = es1.process_messages(msg_out(msg21))?;
     let msg21 = es2.process_messages(msg_out(msg12))?;
     assert_eq!(1, msg21.len());
-    if let GossipOut::Node(_, MessageNode::Events(events)) = &msg21[0] {
+    if let GossipOut::ToNetwork(_, ModuleMessage::Events(events)) = &msg21[0] {
         assert_eq!(
             2,
             events
@@ -44,7 +44,7 @@ async fn test_gossip() -> Result<(), Box<dyn Error>> {
 fn msg_out(mut msgs: Vec<GossipOut>) -> Vec<GossipIn> {
     msgs.drain(..)
         .filter_map(|msg| match msg {
-            GossipOut::Node(id, msg_node) => Some(GossipIn::Node(id, msg_node)),
+            GossipOut::ToNetwork(id, msg_node) => Some(GossipIn::FromNetwork(id, msg_node)),
             _ => None,
         })
         .collect()

--- a/flnode/src/node.rs
+++ b/flnode/src/node.rs
@@ -187,7 +187,7 @@ impl Node {
     /// Requests a list of all connected nodes
     pub async fn request_list(&mut self) -> Result<(), NodeError> {
         self.broker_net
-            .emit_msg(NetworkIn::SendWSUpdateListRequest.into())?;
+            .emit_msg(NetworkIn::WSUpdateListRequest.into())?;
         Ok(())
     }
 

--- a/flnode/tests/helpers/mod.rs
+++ b/flnode/tests/helpers/mod.rs
@@ -66,7 +66,7 @@ impl NetworkSimul {
         for id in self.nodes.keys() {
             if let Some(broker) = self.node_brokers.get_mut(id) {
                 broker
-                    .settle_msg(NetworkOut::RcvWSUpdateList(list.clone()).into())
+                    .settle_msg(NetworkOut::NodeListFromWS(list.clone()).into())
                     .await?;
             }
         }
@@ -134,9 +134,9 @@ impl NetworkSimul {
                     (id_dst, NetworkOut::Connected(*id).into()),
                 ]
             }
-            NetworkMessage::Input(NetworkIn::SendNodeMessage(from_id, msg_str)) => vec![(
+            NetworkMessage::Input(NetworkIn::MessageToNode(from_id, msg_str)) => vec![(
                 from_id,
-                NetworkOut::RcvNodeMessage(id.clone(), msg_str).into(),
+                NetworkOut::MessageFromNode(id.clone(), msg_str).into(),
             )],
             NetworkMessage::WebRTC(WebRTCConnMessage::InputNC(
                 id_dst,

--- a/test/webrtc-libc-wasm/libc/src/main.rs
+++ b/test/webrtc-libc-wasm/libc/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), MainError> {
 
     loop {
         let msg = tap.recv().await.expect("expected message");
-        if let NetworkMessage::Output(NetworkOut::RcvNodeMessage(id, msg_net)) = msg {
+        if let NetworkMessage::Output(NetworkOut::MessageFromNode(id, msg_net)) = msg {
             log::info!("Got message from other node: {}", msg_net);
             if msgs_rcv == 0 {
                 msgs_rcv += 1;
@@ -74,7 +74,7 @@ async fn spawn_node() -> Result<(NodeConfig, Broker<NetworkMessage>), MainError>
 }
 
 async fn send(src: &mut Broker<NetworkMessage>, id: U256, msg: &str) {
-    src.emit_msg(NetworkMessage::Input(NetworkIn::SendNodeMessage(
+    src.emit_msg(NetworkMessage::Input(NetworkIn::MessageToNode(
         id,
         msg.into(),
     )))
@@ -115,7 +115,7 @@ mod tests {
 
     async fn wait_msg(tap: &Receiver<NetworkMessage>, msg: &str) {
         for msg_net in tap {
-            if let NetworkMessage::Output(NetworkOut::RcvNodeMessage(_, nm)) = &msg_net {
+            if let NetworkMessage::Output(NetworkOut::MessageFromNode(_, nm)) = &msg_net {
                 if nm == msg {
                     break;
                 }

--- a/test/webrtc-libc-wasm/wasm/src/lib.rs
+++ b/test/webrtc-libc-wasm/wasm/src/lib.rs
@@ -40,12 +40,12 @@ async fn run_app() -> Result<(), StartError> {
         while let Ok(msg) = rx.try_recv() {
             if let NetworkMessage::Output(reply) = msg {
                 match reply {
-                    NetworkOut::RcvNodeMessage(id, msg_net) => {
+                    NetworkOut::MessageFromNode(id, msg_net) => {
                         log::info!("Got node message: {} / {:?}", id, msg_net);
                         net.remove_subsystem(tap_indx).await?;
                         return Ok(());
                     }
-                    NetworkOut::RcvWSUpdateList(list) => {
+                    NetworkOut::NodeListFromWS(list) => {
                         let other: Vec<NodeInfo> = list
                             .iter()
                             .filter(|n| n.get_id() != nc.info.get_id())
@@ -55,7 +55,7 @@ async fn run_app() -> Result<(), StartError> {
                         if other.len() > 0 {
                             net.emit_msg_dest(
                                 Destination::NoTap,
-                                NetworkIn::SendNodeMessage(
+                                NetworkIn::MessageToNode(
                                     other.get(0).unwrap().get_id(),
                                     "Hello from Rust wasm".to_string(),
                                 )
@@ -67,7 +67,7 @@ async fn run_app() -> Result<(), StartError> {
                 }
             }
         }
-        net.emit_msg(NetworkMessage::Input(NetworkIn::SendWSUpdateListRequest))?;
+        net.emit_msg(NetworkMessage::Input(NetworkIn::WSUpdateListRequest))?;
         wait_ms(1000).await;
     }
 }


### PR DESCRIPTION
- The wrapper of module messages gets renamed from NodeMessage to NetworkWrapper
- The messages between the same modules of two different nodes gets renamed from MessageNode and others to ModuleMessage
- Renamed some of the NetworkIn and NetworkOut messages
