### PR TITLE
Removing ping from browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ build_local_web:
 build_local: build_local_web build_cli
 
 serve_two: kill build_cli
-	( cd cli && cargo run --bin flsignal -- -vv ) &
+	( cd cli && cargo run --bin flsignal -- -v ) &
 	sleep 4
 	( cd cli && ( $(call FLEDGER,1) & $(call FLEDGER,2) & ) )
 


### PR DESCRIPTION
As the ping module has been making troubles lately, it is not loaded anymore. Because it's not used in the new UI, this PR removes it from the setup.