### PR TITLE
Cleanup of broker.add_translator_direct and MODULE_NAME

### DIFF
--- a/flarch/src/broker.rs
+++ b/flarch/src/broker.rs
@@ -205,8 +205,8 @@ impl<I: 'static + Message, O: 'static + Message> Broker<I, O> {
     pub async fn add_translator_direct<TI: Message + 'static, TO: Message + 'static>(
         &mut self,
         mut broker: Broker<TI, TO>,
-        tr_ti_i: Translate<TI, I>,
         tr_o_to: Translate<O, TO>,
+        tr_ti_i: Translate<TI, I>,
     ) -> anyhow::Result<usize> {
         broker.add_translator_i_ti(self.clone(), tr_ti_i).await?;
         self.add_translator_o_to(broker, tr_o_to).await
@@ -403,7 +403,7 @@ impl<I: 'static + Message, O: 'static + Message> Broker<I, O> {
         I: TranslateFrom<TI>,
         O: TranslateInto<TO>,
     {
-        self.add_translator_direct(other, Box::new(I::translate), Box::new(O::translate))
+        self.add_translator_direct(other, Box::new(O::translate), Box::new(I::translate))
             .await?;
         Ok(())
     }

--- a/flmodules/src/dht_router/broker.rs
+++ b/flmodules/src/dht_router/broker.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
 use crate::{
-    flo::realm::RealmID, router::{broker::BrokerRouter, messages::NetworkWrapper}, timer::Timer
+    flo::realm::RealmID,
+    router::{broker::BrokerRouter, messages::NetworkWrapper},
+    timer::Timer,
 };
 use flarch::nodeids::NodeID;
 
@@ -78,11 +80,11 @@ impl DHTRouter {
         intern
             .add_translator_direct(
                 broker.clone(),
-                Box::new(|msg| Some(InternIn::DHTRouter(msg))),
                 Box::new(|msg| match msg {
                     InternOut::DHTRouter(dht) => Some(dht),
                     _ => None,
                 }),
+                Box::new(|msg| Some(InternIn::DHTRouter(msg))),
             )
             .await?;
 
@@ -220,7 +222,7 @@ mod tests {
         wait_ms(1000).await;
 
         // TODO implement rest of test - I have no idea what was here :(
-        
+
         Ok(())
     }
 }

--- a/flmodules/src/dht_storage/broker.rs
+++ b/flmodules/src/dht_storage/broker.rs
@@ -118,11 +118,11 @@ impl DHTStorage {
         intern
             .add_translator_direct(
                 broker.clone(),
-                Box::new(|msg| Some(InternIn::Storage(msg))),
                 Box::new(|msg| match msg {
                     InternOut::Storage(dhtstorage_out) => Some(dhtstorage_out),
                     _ => None,
                 }),
+                Box::new(|msg| Some(InternIn::Storage(msg))),
             )
             .await?;
         timer

--- a/flmodules/src/gossip_events/broker.rs
+++ b/flmodules/src/gossip_events/broker.rs
@@ -19,7 +19,7 @@ use crate::{
 
 pub type BrokerGossip = Broker<GossipIn, GossipOut>;
 
-pub const MODULE_NAME: &str = "Gossip";
+pub(super) const MODULE_NAME: &str = "Gossip";
 
 /// This links the GossipEvent module with a RandomConnections module, so that
 /// all messages are correctly translated from one to the other.

--- a/flmodules/src/router/broker.rs
+++ b/flmodules/src/router/broker.rs
@@ -24,8 +24,8 @@ impl RouterRandom {
         random
             .add_translator_direct(
                 b.clone(),
-                Box::new(Self::translate_rtr_rnd),
                 Box::new(Self::translate_rnd_rtr),
+                Box::new(Self::translate_rtr_rnd),
             )
             .await?;
         Ok(b)

--- a/flmodules/src/router/messages.rs
+++ b/flmodules/src/router/messages.rs
@@ -12,6 +12,7 @@ pub struct NetworkWrapper {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RouterIn {
     NetworkWrapperToNetwork(NodeID, NetworkWrapper),
+    // TODO: Replace this with Network(NetworkOut), and add a Network(NetworkIn) to RouterOut
     Internal(RouterInternal),
 }
 

--- a/flmodules/src/template/broker.rs
+++ b/flmodules/src/template/broker.rs
@@ -14,7 +14,7 @@ use super::{
 
 pub type BrokerEndpoint = Broker<TemplateIn, TemplateOut>;
 
-const MODULE_NAME: &str = "Template";
+pub(super) const MODULE_NAME: &str = "Template";
 
 /// This links the Template module with other modules, so that
 /// all messages are correctly translated from one to the other.

--- a/flmodules/src/template/messages.rs
+++ b/flmodules/src/template/messages.rs
@@ -7,9 +7,7 @@ use flarch::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
-use crate::gossip_events::broker::MODULE_NAME;
-
-use super::core::*;
+use super::{broker::MODULE_NAME, core::*};
 
 /// These are the messages which will be exchanged between the nodes for this
 /// module.

--- a/flmodules/src/testing/network_simul.rs
+++ b/flmodules/src/testing/network_simul.rs
@@ -39,11 +39,11 @@ impl NetworkSimul {
         self.nsh_broker
             .add_translator_direct(
                 nm_broker.clone(),
-                Box::new(move |msg| Some(NSHubIn::FromClient(nc_id, msg))),
                 Box::new(move |msg| {
                     let NSHubOut::ToClient(dst, net_msg) = msg;
                     (dst == nc_id).then_some(net_msg)
                 }),
+                Box::new(move |msg| Some(NSHubIn::FromClient(nc_id, msg))),
             )
             .await?;
         self.nsh_broker

--- a/flmodules/src/testing/router_simul.rs
+++ b/flmodules/src/testing/router_simul.rs
@@ -44,8 +44,8 @@ impl RouterSimul {
         self.nsh_broker
             .add_translator_direct(
                 nm_broker.clone(),
-                Self::net_nsh(id),
                 Self::nsh_net(id.clone()),
+                Self::net_nsh(id),
             )
             .await?;
         self.nsh_broker

--- a/flmodules/src/web_proxy/broker.rs
+++ b/flmodules/src/web_proxy/broker.rs
@@ -21,7 +21,7 @@ use super::{
     response::Response,
 };
 
-const MODULE_NAME: &str = "WebProxy";
+pub(super) const MODULE_NAME: &str = "WebProxy";
 
 #[derive(Debug, Error)]
 pub enum WebProxyError {

--- a/flmodules/src/web_proxy/messages.rs
+++ b/flmodules/src/web_proxy/messages.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 
-use crate::gossip_events::broker::MODULE_NAME;
 use crate::nodeconfig::NodeInfo;
 use crate::Modules;
 
+use super::broker::MODULE_NAME;
 use super::{
     core::*,
     response::{ResponseHeader, ResponseMessage},


### PR DESCRIPTION
- change argument order of add_translator_direct to fit add_translator_link
- correctly import MODULE_NAME from super::broker in template and web_proxy