### PR TITLE
Optimizing signalling and DHT_Router

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -28,8 +28,12 @@ Implement [DHT_STORAGE.md](./DHT_STORAGE.md):
 - DHT Storage
   - add own Flos to DHTConfig.owned
   - verify Flos when they enter the system
-- DHT_routing: check disconnection of nodes when no pings received - doesn't seem to disconnect
-  - also ask other nodes for their list of nodes, so the node can connect there
+- DHT_router
+  - check disconnection of nodes when no pings received - doesn't seem to disconnect
+  - change broadcast: 
+    - add NeighborMessage which is not forwarded
+    - DHTRouterIn::Broadcast sends to all active nodes a NeighborMessage
+    - The answer is also a NeighborMessage
 
 ### Testing
 
@@ -47,6 +51,8 @@ DHT_Router:
 - KBucket.active is only be populated once a node has been confirmed.
   - Needs more testing if nodes fail and how they will be replaced
     This definitely doesn't work currently
+    - Some testing: cached nodes sometimes time out, while active nodes doesn't
+    seem to timeout
 - possible extension to allow for indpendant realms:
   - active nodes are stored in a global vec
   - each realm-kademlia looks in these nodes first to populate the buckets
@@ -81,6 +87,7 @@ Added fledger to blog: https://ineiti.ch/projects/fledger/
 # Some things done
 
 ### Done
+- DHTRouter: also ask other nodes for their list of nodes, so the node can connect there
 - update page in the cli
 - Flo
   - Uses real signatures and verifications now

--- a/cli/flsignal/src/main.rs
+++ b/cli/flsignal/src/main.rs
@@ -18,6 +18,10 @@ struct Args {
     /// System realm - if this is set, no other realms are allowed by default.
     #[arg(long)]
     system_realm: Option<String>,
+
+    /// Maximum list size to return when a node asks for the list of other nodes.
+    #[arg(long)]
+    max_list_len: Option<usize>,
 }
 
 #[tokio::main]
@@ -37,6 +41,7 @@ async fn main() -> anyhow::Result<()> {
         SignalConfig {
             ttl_minutes: 2,
             system_realm,
+            max_list_len: args.max_list_len,
         },
     )
     .await?;

--- a/flarch/src/web_rtc/libc/web_rtc_setup.rs
+++ b/flarch/src/web_rtc/libc/web_rtc_setup.rs
@@ -30,7 +30,6 @@ use crate::{
     broker::{Broker, SubsystemHandler},
     web_rtc::{
         connection::{ConnectionConfig, IceServer},
-        
         messages::{
             ConnType, ConnectionStateMap, DataChannelState, PeerMessage, SetupError,
             SignalingState, WebRTCInput, WebRTCOutput, WebRTCSpawner,
@@ -168,11 +167,10 @@ impl WebRTCConnectionSetupLibc {
                 let mut broker_cl = broker_cl.clone();
                 Box::pin(async move {
                     match s {
-                        RTCPeerConnectionState::Disconnected
-                        | RTCPeerConnectionState::Failed
-                        | RTCPeerConnectionState::Closed => {
+                        RTCPeerConnectionState::Disconnected | RTCPeerConnectionState::Closed => {
                             broker_cl.emit_msg_out(WebRTCOutput::Disconnected)
                         }
+                        RTCPeerConnectionState::Failed => Ok(()),
                         _ => broker_cl.emit_msg_in(WebRTCInput::UpdateState),
                     }
                     .err()

--- a/flarch/src/web_rtc/libc/web_socket_client.rs
+++ b/flarch/src/web_rtc/libc/web_socket_client.rs
@@ -61,7 +61,7 @@ impl WebSocketClient {
             log::debug!("Reconnecting to websocket at {}", self.url);
             write.close().await?;
         } else {
-            log::debug!("Connecting to websocket at {}", self.url);
+            log::trace!("Connecting to websocket at {}", self.url);
         }
         let (websocket, _) = connect_async(self.url.clone()).await?;
         let (write, read) = websocket.split();

--- a/flarch/src/web_rtc/node_connection.rs
+++ b/flarch/src/web_rtc/node_connection.rs
@@ -10,7 +10,7 @@
 //!
 //! _If you come here, I hope you're not trying to debug something that doesn't work.
 //! This code is quite obscure, and should be rewritten for the 5th time or so._
-use crate::broker::{BrokerError, Broker, SubsystemHandler};
+use crate::broker::{Broker, BrokerError, SubsystemHandler};
 use flmacro::platform_async_trait;
 use thiserror::Error;
 
@@ -119,9 +119,7 @@ impl NodeConnection {
             state_incoming: None,
             state_outgoing: None,
         };
-        broker
-            .add_handler(Box::new(nc))
-            .await?;
+        broker.add_handler(Box::new(nc)).await?;
         Ok(broker)
     }
 

--- a/flmodules/src/dht_router/broker.rs
+++ b/flmodules/src/dht_router/broker.rs
@@ -48,7 +48,7 @@ pub type BrokerDHTRouter = Broker<DHTRouterIn, DHTRouterOut>;
 /// all messages are correctly translated from one to the other.
 /// For this example, it uses the RandomConnections module to communicate
 /// with other nodes.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DHTRouter {
     pub broker: BrokerDHTRouter,
     pub stats: watch::Receiver<Stats>,

--- a/flmodules/src/router/broker.rs
+++ b/flmodules/src/router/broker.rs
@@ -131,14 +131,16 @@ impl SubsystemHandler<RouterIn, RouterOut> for RouterNetwork {
             if let RouterIn::Internal(internal) = msg {
                 match internal {
                     RouterInternal::Connected(id) => {
-                        if self.available_connected(id) == (true, false) {
+                        if !self.available_connected(id).1 {
                             self.nodes_connected.push(id);
+                            // out.push(RouterOut::Connected(id));
                             ret = true;
                         }
                     }
                     RouterInternal::Disconnected(id) => {
                         if self.available_connected(id).1 == true {
                             self.nodes_connected.retain(|&other| other != id);
+                            // out.push(RouterOut::Disconnected(id));
                             ret = true;
                         }
                     }

--- a/flmodules/src/router/messages.rs
+++ b/flmodules/src/router/messages.rs
@@ -22,6 +22,8 @@ pub enum RouterOut {
     NodeIDsConnected(NodeIDs),
     NodeInfosConnected(Vec<NodeInfo>),
     NetworkWrapperFromNetwork(NodeID, NetworkWrapper),
+    Disconnected(NodeID),
+    Connected(NodeID),
     SystemConfig(FledgerConfig),
 }
 

--- a/flnode/tests/gossip_large.rs
+++ b/flnode/tests/gossip_large.rs
@@ -42,7 +42,7 @@ async fn gossip_large() -> anyhow::Result<()> {
 
     let mut signal = start_signal().await?;
     let signal_rx = signal.broker.get_tap_out_sync().await?;
-    let nbr_nodes: usize = 50;
+    let nbr_nodes: usize = 100;
     let mut nodes = vec![];
     for i in 0..nbr_nodes {
         nodes.push(start_node(i).await?);
@@ -111,6 +111,7 @@ async fn start_signal() -> anyhow::Result<Signal> {
         SignalConfig {
             ttl_minutes: 2,
             system_realm: None,
+            max_list_len: Some(10),
         },
     )
     .await?;

--- a/test/signal-fledger/src/main.rs
+++ b/test/signal-fledger/src/main.rs
@@ -37,6 +37,7 @@ async fn main() -> anyhow::Result<()> {
         SignalConfig {
             ttl_minutes: 2,
             system_realm: None,
+            max_list_len: None,
         },
     )
     .await?;

--- a/test/webrtc-libc-wasm/libc/src/main.rs
+++ b/test/webrtc-libc-wasm/libc/src/main.rs
@@ -61,6 +61,7 @@ async fn start_signal_server() {
         SignalConfig {
             ttl_minutes: 1,
             system_realm: None,
+            max_list_len: None,
         },
     )
     .await


### PR DESCRIPTION
- SignalConfig::max_list_len so it doesn't return _all_ nodes
- dht_router::ModuleMessage::ConnectedIDsRequest to get IDs from other nodes neighbours
- dht_router::connected, which can be different from core.active_nodes
  - used to send DirectMessage
  - adds potential nodes to core
- improve the dht_large script
- RTCPeerConnection::Failed doesn't send Disconnection
- adding check in Timer if it takes more than 1s, as this indicates a too busy machine
- more details on the connections of the nodes